### PR TITLE
Updating T00 wait time

### DIFF
--- a/common/src/main/java/org/fidoalliance/fdo/test/common/TestCase.java
+++ b/common/src/main/java/org/fidoalliance/fdo/test/common/TestCase.java
@@ -75,7 +75,7 @@ public abstract class TestCase {
   protected Duration fdoDockerUpTimeout = Duration.of(480, ChronoUnit.SECONDS);
 
   // How long to wait for PRI-FIDO T00
-  protected Duration fdoToWait = Duration.of(315, ChronoUnit.SECONDS);
+  protected Duration fdoToWait = Duration.of(45, ChronoUnit.SECONDS);
 
   /**
    * Get the IP address of the server.


### PR DESCRIPTION
  Updating T00 wait time from 315 to 45 seconds.
  This updation helps to reduce the overall smoketest
  execution time.

Signed-off-by: Davis Benny <davis.benny@intel.com>