### PR TITLE
Read API password from env file

### DIFF
--- a/clientSdkTests/src/test/java/org/fidoalliance/fdo/test/ClientSdkTest.java
+++ b/clientSdkTests/src/test/java/org/fidoalliance/fdo/test/ClientSdkTest.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 import org.fidoalliance.fdo.test.common.CsvUtils;
+import org.fidoalliance.fdo.test.common.PropertiesUtils;
 import org.fidoalliance.fdo.test.common.TestCase;
 import org.fidoalliance.fdo.test.common.TestLogger;
 import org.fidoalliance.fdo.test.common.TestProcess;
@@ -44,6 +45,20 @@ public class ClientSdkTest extends TestCase {
   @BeforeGroups("fdo_clientsdk_smoketest")
   public void startFdoDockerService() throws IOException, InterruptedException {
     TestLogger.info("=====> Starting FDO Docker Services");
+
+    try {
+      mfgApiPass = PropertiesUtils.getProperty(
+          testDir + "/binaries/pri-fidoiot/manufacturer/creds.env",
+          "manufacturer_api_password");
+
+      ownerApiPass = PropertiesUtils.getProperty(
+          testDir + "/binaries/pri-fidoiot/owner/creds.env",
+          "owner_api_password");
+    } catch (IOException ex) {
+      Assert.fail("Couldn't read API Password.");
+      throw ex;
+    }
+
     Path mfgDockerPath = Paths.get(testDir + "/binaries/pri-fidoiot/manufacturer");
     Path ownerDockerPath = Paths.get(testDir + "/binaries/pri-fidoiot/owner");
     Path rvDockerPath = Paths.get(testDir + "/binaries/pri-fidoiot/rv");
@@ -108,15 +123,16 @@ public class ClientSdkTest extends TestCase {
     Thread.sleep(shortTimeout.toMillis());
 
     String[] shellCmdVoucher = {"bash", "-cx",
-        "curl -D - --digest -u apiUser:MfgApiPass123 -XGET "
-            + "http://localhost:8039/api/v1/vouchers/abcdef -o ext_voucher"};
+        "curl -D - --digest -u apiUser:" + mfgApiPass + " "
+            + "-XGET http://localhost:8039/api/v1/vouchers/abcdef -o ext_voucher"};
     TestProcess shellVoucher = new TestProcess(testPath, shellCmdVoucher);
     try (TestProcess.Handle hShellCmd = shellVoucher.start()) {
       hShellCmd.waitFor(1000, TimeUnit.MILLISECONDS);
     }
 
     String[] shellCmdTo = {"bash", "-cx",
-        "curl -D - --digest -u apiUser:OwnerApiPass123 --header \"Content-Type: application/cbor\" "
+        "curl -D - --digest -u apiUser:" + ownerApiPass + " "
+            + "--header \"Content-Type: application/cbor\" "
             + "--data-binary @ext_voucher http://localhost:8042/api/v1/owner/vouchers/ -o guid"};
     TestProcess shellTo = new TestProcess(testPath, shellCmdTo);
     try (TestProcess.Handle hShellCmdTo = shellTo.start()) {
@@ -128,7 +144,8 @@ public class ClientSdkTest extends TestCase {
       String guid = br.readLine();
 
       String[] shellCmdServiceInfoActivate = {"bash", "-cx",
-          "curl --location --digest -u apiUser:OwnerApiPass123 --request PUT 'http://localhost:8042/api/v1/device/svi?module=fdo_sys&"
+          "curl --location --digest -u apiUser:" + ownerApiPass + " "
+              + "--request PUT 'http://localhost:8042/api/v1/device/svi?module=fdo_sys&"
               + "var=active&priority=0&bytes=F5' --header 'Content-Type: application/octet-stream'"};
       TestProcess shellServiceInfo = new TestProcess(testPath, shellCmdServiceInfoActivate);
       try (TestProcess.Handle hShellCmd = shellServiceInfo.start()) {
@@ -136,7 +153,8 @@ public class ClientSdkTest extends TestCase {
       }
 
       String[] shellCmdServiceInfoFileTransfer = {"bash", "-cx",
-          "curl --location --digest -u apiUser:OwnerApiPass123 --request PUT 'http://localhost:8042/api/v1/device/svi?module=fdo_sys&"
+          "curl --location --digest -u apiUser:" + ownerApiPass + " "
+              + "--request PUT 'http://localhost:8042/api/v1/device/svi?module=fdo_sys&"
               + "var=filedesc&priority=1&filename=linux64.sh&guid=" + guid
               + "' --header 'Content-Type: application/octet-stream' --data-binary "
               + "'@common/src/main/resources/linux64.sh'"};
@@ -148,7 +166,8 @@ public class ClientSdkTest extends TestCase {
       }
 
       String[] shellCmdServiceInfoExec = {"bash", "-cx",
-          "curl --location --digest -u apiUser:OwnerApiPass123 --request PUT 'http://localhost:8042/api/v1/device/svi?module=fdo_sys&"
+          "curl --location --digest -u apiUser:" + ownerApiPass + " "
+              + "--request PUT 'http://localhost:8042/api/v1/device/svi?module=fdo_sys&"
               + "var=exec&guid=" + guid + "&priority=2&"
               + "bytes=82672F62696E2F73686A6C696E757836342E7368' "
               + "--header 'Content-Type: application/octet-stream'"};

--- a/common/src/main/java/org/fidoalliance/fdo/test/common/PropertiesUtils.java
+++ b/common/src/main/java/org/fidoalliance/fdo/test/common/PropertiesUtils.java
@@ -1,0 +1,26 @@
+// Copyright 2021 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package org.fidoalliance.fdo.test.common;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropertiesUtils {
+
+  /**
+   * Returns the CSV data in String[][] format.
+   */
+  public static String getProperty(String filePath, String key) throws IOException {
+    InputStream input = new FileInputStream(filePath);
+    Properties prop = new Properties();
+    prop.load(input);
+    String value = prop.getProperty(key);
+    if (value.isBlank()) {
+      throw new IOException("Property " + key + "not found.");
+    }
+    return prop.getProperty(key);
+  }
+}

--- a/common/src/main/java/org/fidoalliance/fdo/test/common/TestCase.java
+++ b/common/src/main/java/org/fidoalliance/fdo/test/common/TestCase.java
@@ -62,6 +62,9 @@ public abstract class TestCase {
   protected String mfgOutputDir = null; // Directory where manufacturer will save ownership proxy
   protected String ownerOutputDir = null; // Directory where owner will save ownership proxy
 
+  protected String mfgApiPass = null;
+  protected String ownerApiPass = null;
+
   // A very short wait to complete TO0 after it is scheduled
   protected Duration shortTimeout = Duration.of(5, ChronoUnit.SECONDS);
 

--- a/common/src/main/java/org/fidoalliance/fdo/test/common/TestCase.java
+++ b/common/src/main/java/org/fidoalliance/fdo/test/common/TestCase.java
@@ -75,7 +75,7 @@ public abstract class TestCase {
   protected Duration dockerDownTimeout = Duration.of(20, ChronoUnit.SECONDS);
 
   // How long to wait for FIDO Docker services to start up
-  protected Duration fdoDockerUpTimeout = Duration.of(480, ChronoUnit.SECONDS);
+  protected Duration fdoDockerUpTimeout = Duration.of(300, ChronoUnit.SECONDS);
 
   // How long to wait for PRI-FIDO T00
   protected Duration fdoToWait = Duration.of(45, ChronoUnit.SECONDS);


### PR DESCRIPTION
The PRI codebase is changed to generate the API password using
keys_gen.sh script. The API password needs to be read from the
env file before making REST calls.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>