### PR TITLE
Upgrading log4j version to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <!-- libraries -->
     <net-java-dev-jna.version>5.8.0</net-java-dev-jna.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <testng.version>7.4.0</testng.version>
 
     <!-- maven plugins -->


### PR DESCRIPTION
  CVE-2021-45046 was issued for Log4j 2.15.0 component.

  It was found that the fix to address CVE-2021-44228 in
  Apache Log4j 2.15.0 was incomplete, hence upgrading.

Signed-off-by: Davis Benny <davis.benny@intel.com>