### PR TITLE
Upgrading log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <!-- libraries -->
     <net-java-dev-jna.version>5.8.0</net-java-dev-jna.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <testng.version>7.4.0</testng.version>
 
     <!-- maven plugins -->


### PR DESCRIPTION
  Upgrading log4j version from 2.16.0 to 2.17.1.

Signed-off-by: Davis Benny <davis.benny@intel.com>