### PR TITLE
Upgrade commons-io to 2.14.0 to address CVE-2024-47554

### DIFF
--- a/clientSdkTests/pom.xml
+++ b/clientSdkTests/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.8.0</version>
+      <version>2.14.0</version>
     </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.8.0</version>
+        <version>2.14.0</version>
       </dependency>
 
       <dependency>

--- a/priTests/pom.xml
+++ b/priTests/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.8.0</version>
+      <version>2.14.0</version>
     </dependency>
 
 


### PR DESCRIPTION
Upgraded commons-io from 2.8.0 to 2.14.0 to fix a potential denial of service vulnerability (CVE-2024-47554) in XmlStreamReader.