### PR TITLE
Change docker-compose command to docker compose

### DIFF
--- a/clientSdkTests/src/test/java/org/fidoalliance/fdo/test/ClientSdkTest.java
+++ b/clientSdkTests/src/test/java/org/fidoalliance/fdo/test/ClientSdkTest.java
@@ -67,11 +67,11 @@ public class ClientSdkTest extends TestCase {
     Path dbDockerPath = Paths.get(testDir + "/binaries/pri-fidoiot/db");
 
     try {
-      //TestProcess.execute_dockerCmd(mfgDockerPath.toString(), runDockerService + " --build ");
-      //TestProcess.execute_dockerCmd(rvDockerPath.toString(), runDockerService + " --build ");
-      //TestProcess.execute_dockerCmd(ownerDockerPath.toString(), runDockerService + " --build ");
-      TestProcess.execute_dockerCmd(aioDockerPath.toString(), runDockerService + " --build ");
-      TestProcess.execute_dockerCmd(dbDockerPath.toString(), runDockerService + " --build ");
+      //TestProcess.execute_dockerCmd(mfgDockerPath.toString(), runDockerService);
+      //TestProcess.execute_dockerCmd(rvDockerPath.toString(), runDockerService);
+      //TestProcess.execute_dockerCmd(ownerDockerPath.toString(), runDockerService);
+      TestProcess.execute_dockerCmd(aioDockerPath.toString(), runDockerService);
+      TestProcess.execute_dockerCmd(dbDockerPath.toString(), runDockerService);
       Thread.sleep(fdoDockerUpTimeout.toMillis());
     } catch (Exception e) {
       e.printStackTrace();

--- a/common/src/main/java/org/fidoalliance/fdo/test/common/TestCase.java
+++ b/common/src/main/java/org/fidoalliance/fdo/test/common/TestCase.java
@@ -33,8 +33,8 @@ public abstract class TestCase {
 
   protected static final String resultFile = "result.txt";
   //Iot Platform SDK Docker commands
-  protected static final String runDockerService = "docker-compose up";
-  protected static final String downDockerService = "docker-compose down";
+  protected static final String runDockerService = "docker compose up --build";
+  protected static final String downDockerService = "docker compose down";
   // Spring arguments
   protected static final String D_JAVA_LIBRARY_PATH = "-Djava.library.path=";
   // Environment constants
@@ -75,7 +75,7 @@ public abstract class TestCase {
   protected Duration dockerDownTimeout = Duration.of(20, ChronoUnit.SECONDS);
 
   // How long to wait for FIDO Docker services to start up
-  protected Duration fdoDockerUpTimeout = Duration.of(360, ChronoUnit.SECONDS);
+  protected Duration fdoDockerUpTimeout = Duration.of(120, ChronoUnit.SECONDS);
 
   // How long to wait for PRI-FIDO T00
   protected Duration fdoToWait = Duration.of(45, ChronoUnit.SECONDS);

--- a/priTests/src/test/java/org/fidoalliance.fdo/test/PriSmokeTest.java
+++ b/priTests/src/test/java/org/fidoalliance.fdo/test/PriSmokeTest.java
@@ -67,11 +67,11 @@ public class PriSmokeTest extends TestCase {
     Path dbDockerPath = Paths.get(testDir + "/binaries/pri-fidoiot/db");
 
     try {
-//      TestProcess.execute_dockerCmd(mfgDockerPath.toString(), runDockerService + " --build ");
-//      TestProcess.execute_dockerCmd(rvDockerPath.toString(), runDockerService + " --build ");
-//      TestProcess.execute_dockerCmd(ownerDockerPath.toString(), runDockerService + " --build ");
-      TestProcess.execute_dockerCmd(aioDockerPath.toString(), runDockerService + " --build ");
-      TestProcess.execute_dockerCmd(dbDockerPath.toString(), runDockerService + " --build ");
+//      TestProcess.execute_dockerCmd(mfgDockerPath.toString(), runDockerService);
+//      TestProcess.execute_dockerCmd(rvDockerPath.toString(), runDockerService);
+//      TestProcess.execute_dockerCmd(ownerDockerPath.toString(), runDockerService);
+      TestProcess.execute_dockerCmd(aioDockerPath.toString(), runDockerService);
+      TestProcess.execute_dockerCmd(dbDockerPath.toString(), runDockerService);
       Thread.sleep(fdoDockerUpTimeout.toMillis());
     } catch (Exception e) {
       e.printStackTrace();


### PR DESCRIPTION
The DB and AIO containers failed to start in the test scenarios due to missing `docker-compose` command in the CI pipeline. Switched to `docker compose`.